### PR TITLE
Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/libindic/normalizer/core.py
+++ b/libindic/normalizer/core.py
@@ -61,7 +61,7 @@ class Normalizer:
             text_raw = rules_file.readline()
             try:
                 text = text_raw.decode('utf-8')
-            except AttributeError:
+            except (AttributeError, UnicodeEncodeError):
                 text = text_raw
             if text == "":
                 break

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 namespace_packages = libindic
 packages = libindic.normalizer
-python_requires = >=3.3
+python_requires = >=2.7
 tests_require =
   pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37, py38, pep8
+envlist = py27, py35, py36, py37, py38, pep8
 
 [testenv]
 commands = make test


### PR DESCRIPTION
Setuptools allows namespace packages to work on python 2 using -nspkg.pth files. Therefore we can re-enable the python 2 support.