### PR TITLE
Fix: Handle multi-line strings

### DIFF
--- a/libindic/normalizer/core.py
+++ b/libindic/normalizer/core.py
@@ -30,6 +30,10 @@ class Normalizer:
         self.rulesDict = dict()
 
     def normalize(self, text):
+        out = [ self.normalize_line(line) for line in text.split('\n') ];
+        return '\n'.join(out)
+
+    def normalize_line(self, text):
         self.rulesDict = self.LoadRules()
         words = text.split(" ")
         result = []


### PR DESCRIPTION
Current implementation only cares about words separated by space. Chillu appearing at the end of the line is not handled properly.  
![image](https://user-images.githubusercontent.com/1652903/218678576-607717df-ebde-4bcd-92ea-5a29bc897485.png)

This PR fixes this issue
